### PR TITLE
[10.0][FIX]l10n_it_dichiarazione_intento-split importo fattura su più dichiarazioni

### DIFF
--- a/l10n_it_dichiarazione_intento/models/sale.py
+++ b/l10n_it_dichiarazione_intento/models/sale.py
@@ -19,7 +19,7 @@ class SaleOrder(models.Model):
                     sale.date_order)
                 if dichiarazioni:
                     sale.fiscal_position_id = \
-                        dichiarazioni.fiscal_position_id.id
+                        dichiarazioni[0].fiscal_position_id.id
 
     @api.onchange('date_order')
     def onchange_date_order(self):


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/pull/789#issuecomment-528745232
In caso di un cliente con più dichiarazioni valide, se una fattura aveva un valore superiore al residuo della prima dichiarazione trovata, veniva segnalato che il plafond non era sufficiente anche se c'erano altre dichiarazioni valide.

Questa PR cerca tutte le dichiarazioni valide e se il residuo totale è sufficiente splitta l'importo della fattura sulle dichiarazioni necessarie partendo dalla più vecchia.

Anche in caso di note di credito il totale viene riassegnato su più dichiarazioni, partendo dalla più recente ancora aperta (scartando quelle con plafond intatto) e se necessario riaprendo quelle chiuse.

Sistemato anche il bug sulla _set_fiscal_position in caso di più dichiarazioni valide (viene presa in considerazione la prima)

https://github.com/OCA/l10n-italy/pull/789#discussion_r321175273
Aggiunta anche alla funzione _compute_amounts la dipendenza dal campo limit_amount